### PR TITLE
Change the Ubuntu runner to 22.04, due to deprecation

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -18,7 +18,7 @@ jobs:
           - '3.11.x'
           - '3.12.x'
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - windows-latest
           - macos-latest
 


### PR DESCRIPTION
Context: https://github.com/actions/runner-images/issues/11101