### PR TITLE
Allow overriding model per index

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,15 +39,26 @@ INSTALLED_APPS = [
 ## 3. Choose the vector search engine and the embedding model
 
 Do not close the `settings.py` file yet. You need to configure the vector search engine and the embedding model. Add the
-`SEMANTIC_SEARCH` dictionary to the `settings.py` file of the project, with the desired configuration. Here is an
-example of the configuration:
+`SEMANTIC_SEARCH` dictionary to the `settings.py` file of the project. Here is a basic example:
 
 ```python title="settings.py"
---8<-- "src/django_semantic_search/default_settings.py"
+SEMANTIC_SEARCH = {
+    "vector_store": {
+        "backend": "django_semantic_search.backends.qdrant.QdrantBackend",
+        "configuration": {
+            "location": "http://localhost:6333",
+        },
+    },
+    "default_embeddings": {
+        "model": "django_semantic_search.embeddings.SentenceTransformerModel",
+        "configuration": {
+            "model_name": "sentence-transformers/all-MiniLM-L6-v2",
+        },
+    },
+}
 ```
 
-We defined the `Qdrant` vector search engine and the `all-MiniLM-L6-v2` embedding model. You can choose other models
-from the [Sentence Transformers](https://www.sbert.net) library, for the time being.
+For more advanced configurations, including using different embedding models for different fields, see the [Embedding Models](api/embeddings.md) documentation.
 
 ## 4. Create a model class (skip if you already have one)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,12 +18,58 @@ INSTALLED_APPS = [
 ]
 ```
 
-All the library configuration is also done in the `settings.py` file of the project, via the `SEMANTIC_SEARCH`
+All the library configuration is done in the `settings.py` file of the project, via the `SEMANTIC_SEARCH`
 dictionary. Here is a full example of the configuration:
 
 ```python title="settings.py"
 --8<-- "src/django_semantic_search/default_settings.py"
 ```
+
+### Using Different Embedding Models
+
+You can define multiple embedding models in the settings and use them for different fields in your documents:
+
+```python title="settings.py"
+SEMANTIC_SEARCH = {
+    "default_embeddings": {
+        "model": "django_semantic_search.embeddings.SentenceTransformerModel",
+        "configuration": {
+            "model_name": "sentence-transformers/all-MiniLM-L6-v2",
+        },
+    },
+    "embedding_models": {
+        "title_model": {
+            "model": "django_semantic_search.embeddings.SentenceTransformerModel",
+            "configuration": {
+                "model_name": "sentence-transformers/all-mpnet-base-v2",
+                "document_prompt": "Title: ",
+            },
+        },
+        "content_model": {
+            "model": "django_semantic_search.embeddings.OpenAIEmbeddingModel",
+            "configuration": {
+                "model": "text-embedding-3-small",
+            },
+        },
+    }
+}
+```
+
+Then reference these models in your document definitions:
+
+```python title="books/documents.py"
+@register_document
+class BookDocument(Document):
+    class Meta:
+        model = Book
+        indexes = [
+            VectorIndex("title", embedding_model="title_model"),  # Uses title_model
+            VectorIndex("content", embedding_model="content_model"),  # Uses content_model
+            VectorIndex("description"),  # Uses default_embeddings
+        ]
+```
+
+If no specific embedding model is specified for a `VectorIndex`, it will use the model defined in `default_embeddings`.
 
 ## Frequently Asked Questions
 

--- a/examples/simple_django_app/products/documents.py
+++ b/examples/simple_django_app/products/documents.py
@@ -1,10 +1,9 @@
 import django_semantic_search as dss
-from django_semantic_search import register_document
 
 from .models import Product
 
 
-@register_document
+@dss.register_document
 class ProductDocument(dss.Document):
     """
     Maps the Product model to a document for the semantic search engine.

--- a/src/django_semantic_search/default_settings.py
+++ b/src/django_semantic_search/default_settings.py
@@ -9,14 +9,33 @@ SEMANTIC_SEARCH = {
         },
     },
     # Default embeddings are used to generate the embeddings for the documents if no embeddings are provided.
-    # For the time being, there is no way to provide embeddings for the documents, so the default embeddings
-    # are used for all the documents.
+    # This model will be used when no specific embedding_model is specified for a VectorIndex.
     "default_embeddings": {
         # Either the path to the embeddings model class or the class itself
         "model": "django_semantic_search.embeddings.SentenceTransformerModel",
         # Configuration is passed directly to the embeddings model class during initialization.
         "configuration": {
             "model_name": "sentence-transformers/all-MiniLM-L6-v2",
+        },
+    },
+    # Optional named embedding models that can be referenced by VectorIndex instances.
+    # This allows using different embedding models for different fields in your documents.
+    "embedding_models": {
+        # Each key is a unique identifier for the embedding model
+        "title_model": {
+            # Either the path to the embeddings model class or the class itself
+            "model": "django_semantic_search.embeddings.SentenceTransformerModel",
+            # Configuration is passed directly to the embeddings model class during initialization.
+            "configuration": {
+                "model_name": "sentence-transformers/all-mpnet-base-v2",
+                "document_prompt": "Title: ",
+            },
+        },
+        "content_model": {
+            "model": "django_semantic_search.embeddings.OpenAIEmbeddingModel",
+            "configuration": {
+                "model": "text-embedding-3-small",
+            },
         },
     },
 }

--- a/src/django_semantic_search/documents.py
+++ b/src/django_semantic_search/documents.py
@@ -23,17 +23,18 @@ class VectorIndex:
     but also allows to surpass the default settings of django-semantic-search.
     """
 
-    # TODO: allow specifying the embedding model for the index
-
     def __init__(
         self,
         *fields: str,
         index_name: Optional[str] = None,
         distance: Distance = Distance.COSINE,
+        embedding_model: Optional[str] = None,
     ):
         """
         :param fields: model fields to index together.
         :param index_name: name of the index to use in a backend. By default, it is the concatenation of the fields.
+        :param distance: distance metric to use for similarity search.
+        :param embedding_model: name of the embedding model to use, must be defined in SEMANTIC_SEARCH settings.
         """
         # Loading the default embedding model here, as otherwise it would create a circular import
         from django_semantic_search.utils import load_embedding_model
@@ -44,7 +45,7 @@ class VectorIndex:
         self._fields: List[str] = list(fields)
         self._index_name = index_name or "_".join(fields)
         self._distance = distance
-        self._embedding_model = load_embedding_model()
+        self._embedding_model = load_embedding_model(embedding_model)
 
     def validate(self, model_cls: Type[models.Model]):
         """

--- a/src/django_semantic_search/utils.py
+++ b/src/django_semantic_search/utils.py
@@ -1,4 +1,5 @@
 from functools import cache
+from typing import Optional
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -8,17 +9,28 @@ from django_semantic_search.embeddings.base import DenseTextEmbeddingModel
 
 
 @cache
-def load_embedding_model() -> DenseTextEmbeddingModel:
+def load_embedding_model(model_name: Optional[str] = None) -> DenseTextEmbeddingModel:
     """
-    Load the default dense embedding model, as specified in the settings.
-    :return: default embedding model instance.
+    Load the embedding model specified in settings.
+    :param model_name: name of the model configuration to use from settings
+    :return: embedding model instance
     """
     semantic_search_settings = settings.SEMANTIC_SEARCH
-    model_cls = semantic_search_settings["default_embeddings"]["model"]
+
+    if model_name is None:
+        model_config = semantic_search_settings["default_embeddings"]
+    else:
+        if "embedding_models" not in semantic_search_settings:
+            raise ValueError("No embedding_models defined in settings")
+        if model_name not in semantic_search_settings["embedding_models"]:
+            raise ValueError(f"Embedding model {model_name} not found in settings")
+        model_config = semantic_search_settings["embedding_models"][model_name]
+
+    model_cls = model_config["model"]
     if isinstance(model_cls, str):
         model_cls = import_string(model_cls)
-    model_config = semantic_search_settings["default_embeddings"]["configuration"]
-    return model_cls(**model_config)
+    model_configuration = model_config["configuration"]
+    return model_cls(**model_configuration)
 
 
 @cache

--- a/tests/django_semantic_search/test_vector_index_embeddings.py
+++ b/tests/django_semantic_search/test_vector_index_embeddings.py
@@ -20,7 +20,7 @@ class TestVectorIndexEmbeddings:
         settings.SEMANTIC_SEARCH = {
             "vector_store": {
                 "backend": "django_semantic_search.backends.qdrant.QdrantBackend",
-                "configuration": {"location": "http://localhost:6333"},
+                "configuration": {"location": ":memory:"},
             },
             "default_embeddings": {
                 "model": "django_semantic_search.embeddings.SentenceTransformerModel",

--- a/tests/django_semantic_search/test_vector_index_embeddings.py
+++ b/tests/django_semantic_search/test_vector_index_embeddings.py
@@ -1,0 +1,93 @@
+import pytest
+from django.conf import settings
+from django.db import models
+
+from django_semantic_search import Document, VectorIndex, register_document
+
+
+class TestModel(models.Model):
+    title = models.CharField(max_length=255)
+    content = models.TextField()
+
+    class Meta:
+        app_label = "test_vector_index"
+
+
+@pytest.mark.integration
+class TestVectorIndexEmbeddings:
+    @pytest.fixture(autouse=True)
+    def setup_settings(self):  # Remove the settings parameter
+        settings.SEMANTIC_SEARCH = {
+            "vector_store": {
+                "backend": "django_semantic_search.backends.qdrant.QdrantBackend",
+                "configuration": {"location": "http://localhost:6333"},
+            },
+            "default_embeddings": {
+                "model": "django_semantic_search.embeddings.SentenceTransformerModel",
+                "configuration": {
+                    "model_name": "sentence-transformers/all-MiniLM-L6-v2",
+                },
+            },
+            "embedding_models": {
+                "title_model": {
+                    "model": "django_semantic_search.embeddings.SentenceTransformerModel",
+                    "configuration": {
+                        "model_name": "sentence-transformers/all-mpnet-base-v2",
+                        "document_prompt": "Title: ",
+                    },
+                },
+                "content_model": {
+                    "model": "django_semantic_search.embeddings.SentenceTransformerModel",
+                    "configuration": {
+                        "model_name": "sentence-transformers/all-MiniLM-L6-v2",
+                        "document_prompt": "Content: ",
+                    },
+                },
+            },
+        }
+
+    def test_different_models_for_indexes(self):
+        @register_document
+        class TestDocument(Document):
+            class Meta:
+                model = TestModel
+                indexes = [
+                    VectorIndex("title", embedding_model="title_model"),
+                    VectorIndex("content", embedding_model="content_model"),
+                ]
+
+        # Create test instances
+        instance = TestModel(title="Test Title", content="Test Content")
+
+        # Get embeddings for both fields
+        title_embedding = TestDocument.meta.indexes[0].get_model_embedding(instance)
+        content_embedding = TestDocument.meta.indexes[1].get_model_embedding(instance)
+
+        # Embeddings should be different sizes due to different models
+        assert len(title_embedding) != len(content_embedding)
+
+    def test_default_model_fallback(self):
+        @register_document
+        class TestDocument(Document):
+            class Meta:
+                model = TestModel
+                indexes = [
+                    VectorIndex("title"),  # Uses default model
+                    VectorIndex("content", embedding_model="content_model"),
+                ]
+
+        instance = TestModel(title="Test Title", content="Test Content")
+
+        # Both embeddings should work
+        title_embedding = TestDocument.meta.indexes[0].get_model_embedding(instance)
+        content_embedding = TestDocument.meta.indexes[1].get_model_embedding(instance)
+
+        assert isinstance(title_embedding, (list, tuple))
+        assert isinstance(content_embedding, (list, tuple))
+
+    def test_invalid_model_name(self):
+        with pytest.raises(ValueError) as exc_info:
+            VectorIndex("title", embedding_model="non_existent_model")
+        assert "Embedding model non_existent_model not found in settings" in str(
+            exc_info.value
+        )


### PR DESCRIPTION
Up till now, each vector index had to use the default embedding model. This PR introduces named embedding models and allows setting them per index, so we can have multiple models in a single application.