### PR TITLE
Do not overwrite user settings with the default ones

### DIFF
--- a/src/django_semantic_search/apps.py
+++ b/src/django_semantic_search/apps.py
@@ -10,7 +10,6 @@ class DjangoSemanticSearchConfig(AppConfig):
 
     def ready(self):
         # Load the default settings
-        # TODO: verify whether the settings are already loaded, and not overwrite them
         for setting in dir(default_settings):
-            if setting.isupper():
+            if setting.isupper() and not hasattr(settings, setting):
                 setattr(settings, setting, getattr(default_settings, setting))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import django
-from mocks import MockDenseTextEmbeddingModel, MockVectorSearchBackend
+from mocks import test_settings
 
 
 def pytest_configure(config):
@@ -13,16 +13,7 @@ def pytest_configure(config):
                 "AUTOCOMMIT": True,
             }
         },
-        SEMANTIC_SEARCH={
-            "vector_store": {
-                "backend": MockVectorSearchBackend,
-                "configuration": {},
-            },
-            "default_embeddings": {
-                "model": MockDenseTextEmbeddingModel,
-                "configuration": {},
-            },
-        },
+        SEMANTIC_SEARCH=test_settings,
     )
 
     django.setup()

--- a/tests/django_semantic_search/test_apps.py
+++ b/tests/django_semantic_search/test_apps.py
@@ -1,6 +1,7 @@
 from mocks import test_settings
 
 import django_semantic_search
+from django_semantic_search import default_settings
 from django_semantic_search.apps import DjangoSemanticSearchConfig
 
 
@@ -19,6 +20,26 @@ def test_custom_settings_are_not_overwritten_on_ready():
 
     assert hasattr(settings, "SEMANTIC_SEARCH")
     assert settings.SEMANTIC_SEARCH == test_settings
+
+    # Restore the initial settings
+    setattr(settings, "SEMANTIC_SEARCH", init_semantic_search_settings)
+
+
+def test_default_settings_are_set_on_ready():
+    from django.conf import settings
+
+    # Save the initial settings and delete them so that the default settings are set
+    init_semantic_search_settings = getattr(settings, "SEMANTIC_SEARCH")
+    delattr(settings, "SEMANTIC_SEARCH")
+
+    # Run ready and check that the settings are not overwritten
+    config = DjangoSemanticSearchConfig(
+        "django_semantic_search", django_semantic_search
+    )
+    config.ready()
+
+    assert hasattr(settings, "SEMANTIC_SEARCH")
+    assert settings.SEMANTIC_SEARCH == default_settings.SEMANTIC_SEARCH
 
     # Restore the initial settings
     setattr(settings, "SEMANTIC_SEARCH", init_semantic_search_settings)

--- a/tests/django_semantic_search/test_apps.py
+++ b/tests/django_semantic_search/test_apps.py
@@ -1,0 +1,24 @@
+from mocks import test_settings
+
+import django_semantic_search
+from django_semantic_search.apps import DjangoSemanticSearchConfig
+
+
+def test_custom_settings_are_not_overwritten_on_ready():
+    from django.conf import settings
+
+    # Save the initial settings and set custom settings
+    init_semantic_search_settings = getattr(settings, "SEMANTIC_SEARCH")
+    setattr(settings, "SEMANTIC_SEARCH", test_settings)
+
+    # Run ready and check that the settings are not overwritten
+    config = DjangoSemanticSearchConfig(
+        "django_semantic_search", django_semantic_search
+    )
+    config.ready()
+
+    assert hasattr(settings, "SEMANTIC_SEARCH")
+    assert settings.SEMANTIC_SEARCH == test_settings
+
+    # Restore the initial settings
+    setattr(settings, "SEMANTIC_SEARCH", init_semantic_search_settings)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -64,3 +64,16 @@ class MockVectorSearchBackend(BaseVectorSearchBackend):
 
     def delete(self, document_id: DocumentID) -> None:
         del self._documents[self.index_configuration.namespace][document_id]
+
+
+# Configuration for the tests
+test_settings = {
+    "vector_store": {
+        "backend": MockVectorSearchBackend,
+        "configuration": {},
+    },
+    "default_embeddings": {
+        "model": MockDenseTextEmbeddingModel,
+        "configuration": {},
+    },
+}


### PR DESCRIPTION
As reported in #7, default settings were overriding user settings by default. This PR contains a fix and a regression test to make sure it's now fixed.